### PR TITLE
chore(deps): add dependencies label to Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,5 +27,8 @@
   ],
   "schedule": [
     "before 5am on monday"
+  ],
+  "labels": [
+    "dependencies"
   ]
 }


### PR DESCRIPTION
Adds `dependencies` label to all Renovate PRs for better filtering and organization.

This makes the Renovate config consistent across all repositories.