### PR TITLE
Enable lockFileMaintenance in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,5 +28,8 @@
   "labels": [
     "dependencies"
   ],
-  "minimumReleaseAge": "7 days"
+  "minimumReleaseAge": "7 days",
+  "lockFileMaintenance": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
This ensures Renovate periodically updates lockfile-only dependencies (transitive deps and those without version pins) that would otherwise never get updated.